### PR TITLE
extract lock-skipping helper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 sudo: false
+before_install:
+  - '[[ "$(npm -v)" =~ ^2 ]] && npm i -g npm@latest || true'
 install:
   - npm install
   - npm run prepare

--- a/packages/munar-helper-booth-lockskip/README.md
+++ b/packages/munar-helper-booth-lockskip/README.md
@@ -1,0 +1,33 @@
+# munar-helper-booth-lockskip
+
+Helper function for "lock-skipping" DJs in [Munar] plugins.
+
+Intended for Adapters with a DJ Booth and a DJ History, like [plug.dj] or
+[üWave].
+
+## Installation
+
+```shell
+$ npm install --save munar-helper-booth-lockskip
+```
+
+## Usage
+
+```js
+import lockskip from 'munar-helper-booth-lockskip'
+
+// Skip DJ and move them to the second position in the wait list
+await lockskip(adapter)
+
+// Skip DJ and move them to a custom (zero-indexed) position in the wait list
+await lockskip(adapter, { position: 5 })
+```
+
+## License
+
+[ISC]
+
+[Munar]: http://munar.space
+[plug.dj]: https://npmjs.com/package/munar-adapter-plugdj
+[üWave]: https://npmjs.com/package/munar-adapter-uwave
+[ISC]: ../../LICENSE

--- a/packages/munar-helper-booth-lockskip/package.json
+++ b/packages/munar-helper-booth-lockskip/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "munar-helper-booth-lockskip",
+  "version": "1.0.0",
+  "description": "Helper function to lock-skip DJ Booths with Munar bots.",
+  "main": "lib/index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "munar-helper"
+  ],
+  "author": "Renée Kooi <renee@kooi.me>",
+  "license": "ISC",
+  "dependencies": {
+    "delay": "^1.3.1"
+  }
+}

--- a/packages/munar-helper-booth-lockskip/src/__tests__/index.js
+++ b/packages/munar-helper-booth-lockskip/src/__tests__/index.js
@@ -1,0 +1,64 @@
+/* global jest, expect, it */
+import lockskip from '../'
+
+it('uses an adapter\'s lockskip method if available', async () => {
+  const booth = {
+    lockskip: jest.fn().mockReturnValue(Promise.resolve())
+  }
+  const adapter = {
+    getDJBooth: jest.fn().mockReturnValue(booth)
+  }
+
+  await lockskip(adapter, { position: 2 })
+
+  expect(booth.lockskip).toHaveBeenCalledWith(
+    { position: 2 }
+  )
+})
+
+it('moves the old DJ in the waitlist manually', async () => {
+  const booth = {
+    getDJ: jest.fn()
+      .mockReturnValueOnce({ id: 1, username: 'Abc' })
+      .mockReturnValueOnce({ id: 2, username: 'Def' }),
+    skip: jest.fn(() => Promise.resolve())
+  }
+  const waitlist = {
+    move: jest.fn(() => Promise.resolve())
+  }
+  const adapter = {
+    getDJBooth: jest.fn(() => booth),
+    getWaitlist: jest.fn(() => waitlist)
+  }
+
+  await lockskip(adapter, { position: 1 })
+
+  expect(booth.skip).toHaveBeenCalled()
+  expect(waitlist.move).toHaveBeenCalled()
+})
+
+it('gives a useful error message if the adapter does not support skipping DJ Booths', async () => {
+  let threw = 0
+  try {
+    await lockskip({})
+  } catch (e) {
+    expect(e.message).toMatch(/does not support booth skipping/)
+    threw += 1
+  }
+
+  const booth = {
+    skip: 'not a function'
+  }
+  const adapter = {
+    getDJBooth: jest.fn(() => booth)
+  }
+
+  try {
+    await lockskip(adapter)
+  } catch (e) {
+    expect(e.message).toMatch(/does not support booth skipping/)
+    threw += 1
+  }
+
+  expect(threw).toBe(2)
+})

--- a/packages/munar-helper-booth-lockskip/src/index.js
+++ b/packages/munar-helper-booth-lockskip/src/index.js
@@ -1,0 +1,34 @@
+import delay from 'delay'
+
+const supportsBoothSkipping = (adapter) =>
+  typeof adapter.getDJBooth === 'function' &&
+  typeof adapter.getDJBooth().skip === 'function'
+const supportsBoothLockskipping = (adapter) =>
+  typeof adapter.getDJBooth === 'function' &&
+  typeof adapter.getDJBooth().lockskip === 'function'
+
+export default async function lockskip (adapter, { position = 1 } = {}) {
+  if (supportsBoothLockskipping(adapter)) {
+    const booth = adapter.getDJBooth()
+    await booth.lockskip({ position })
+  } else if (supportsBoothSkipping(adapter)) {
+    // Attempt to lockskip manually.
+    const booth = adapter.getDJBooth()
+    const waitlist = adapter.getWaitlist()
+    const dj = await booth.getDJ()
+    // Find the waitlist length to determine whether the DJ should be moved
+    // after being skipped, or default to always moving the DJ to the lockskip
+    // position.
+    const waitlistLength = typeof waitlist.all === 'function'
+      ? (await waitlist.all()).length
+      : Infinity
+    // Attempt to lockskip manually.
+    await booth.skip()
+    if (waitlistLength > position) {
+      await delay(1000)
+      await waitlist.move(dj.id, position)
+    }
+  } else {
+    throw new Error('Adapter does not support booth skipping.')
+  }
+}

--- a/packages/munar-plugin-dj-history-skip/package.json
+++ b/packages/munar-plugin-dj-history-skip/package.json
@@ -13,7 +13,8 @@
   "license": "ISC",
   "dependencies": {
     "delay": "^1.3.1",
-    "moment": "^2.15.1"
+    "moment": "^2.15.1",
+    "munar-helper-booth-lockskip": "^1.0.0"
   },
   "peerDependencies": {
     "munar-core": "^1.0.0"


### PR DESCRIPTION
Most plugins that want to autoskip booths probably need to lockskip, so better to refer to `munar-helper-booth-lockskip` rather than reinventing it for every plugin.