### PR TITLE
Add media blacklist plugin.

### DIFF
--- a/packages/munar-plugin-emotes/src/index.js
+++ b/packages/munar-plugin-emotes/src/index.js
@@ -126,7 +126,9 @@ export default class Emotes extends Plugin {
       message.reply(`Emotes can be found at ${url} !`)
       return
     }
-    const emotes = await this.model('Emote').find().sort('id')
+    const emotes = await this.model('Emote')
+      .find()
+      .sort('_id')
     const emoteIds = emotes.map((emote) => emote.id)
     message.reply(`Emotes: ${emoteIds.join(', ')}`)
   }
@@ -155,7 +157,9 @@ export default class Emotes extends Plugin {
   async serve (req, res) {
     res.setHeader('content-type', 'text/html')
 
-    const emotes = await this.model('Emote').find().sort('id')
+    const emotes = await this.model('Emote')
+      .find()
+      .sort('_id')
     return renderEmotesList(emotes)
   }
 }

--- a/packages/munar-plugin-media-blacklist/README.md
+++ b/packages/munar-plugin-media-blacklist/README.md
@@ -14,23 +14,32 @@ $ npm install --save munar-plugin-media-blacklist
 The Blacklist plugin adds chat commands for managing the blacklist. All commands
 can only be used by moderators.
 
-### `!blacklist "<reason>"`
+### `!blacklist add "<reason>"`
 
 Add the current media to the blacklist.
 
 **Example**
 
- - !blacklist "This track has terrible audio quality."
+ - !blacklist add "This track has terrible audio quality."
 
-### `!blacklist <media> "<reason>"`
+### `!blacklist add <media> "<reason>"`
 
 Add a specific media to the blacklist. `<media>` contains the source type and
 source ID, separated by a colon `:`.
 
 **Example**
 
- - !blacklist youtube:nkMgmtU3rno "Video flickers A LOT. Please play an
-   alternative version that doesn't trigger seizures."
+ - !blacklist add youtube:nkMgmtU3rno "Video flickers A LOT. Please play an
+   alternative version that doesn't cause headaches."
+
+### `!blacklist remove <media>`
+
+Remove a media from the blacklist. `<media>` contains the source type and
+source ID, separated by a colon `:`.
+
+**Example**
+
+ - !blacklist remove youtube:qLphUlWywF4
 
 ## Usage
 

--- a/packages/munar-plugin-media-blacklist/README.md
+++ b/packages/munar-plugin-media-blacklist/README.md
@@ -1,0 +1,52 @@
+# munar-plugin-media-blacklist
+
+[Munar][] plugin for blacklisting media. Works with DJ Booth adapters like
+[plug.dj][] and [üWave][].
+
+## Installation
+
+```shell
+$ npm install --save munar-plugin-media-blacklist
+```
+
+## Commands
+
+The Blacklist plugin adds chat commands for managing the blacklist. All commands
+can only be used by moderators.
+
+### `!blacklist "<reason>"`
+
+Add the current media to the blacklist.
+
+**Example**
+
+ - !blacklist "This track has terrible audio quality."
+
+### `!blacklist <media> "<reason>"`
+
+Add a specific media to the blacklist. `<media>` contains the source type and
+source ID, separated by a colon `:`.
+
+**Example**
+
+ - !blacklist youtube:nkMgmtU3rno "Video flickers A LOT. Please play an
+   alternative version that doesn't trigger seizures."
+
+## Usage
+
+```json
+{
+  "plugins": [
+    "media-blacklist"
+  ]
+}
+```
+
+## License
+
+[ISC][]
+
+[plug.dj]: ../munar-adapter-plugdj#readme
+[üWave]: ../munar-adapter-uwave#readme
+[Munar]: http://munar.space
+[ISC]: ../../LICENSE

--- a/packages/munar-plugin-media-blacklist/package.json
+++ b/packages/munar-plugin-media-blacklist/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "munar-plugin-media-blacklist",
+  "version": "0.0.0",
+  "description": "Munar plugin for blacklisting and auto-skipping media.",
+  "main": "lib/index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "munar-plugin"
+  ],
+  "author": "Renée Kooi <renee@kooi.me>",
+  "license": "ISC",
+  "dependencies": {
+    "munar-helper-booth-lockskip": "^1.0.0",
+    "ultron": "^1.1.0"
+  },
+  "peerDependencies": {
+    "munar-core": "^1.0.0"
+  }
+}

--- a/packages/munar-plugin-media-blacklist/src/BlacklistedMedia.js
+++ b/packages/munar-plugin-media-blacklist/src/BlacklistedMedia.js
@@ -1,0 +1,13 @@
+import { UserModel } from 'munar-core'
+
+export default class BlacklistedMedia {
+  static collection = 'media_blacklist'
+  static timestamps = true
+
+  static schema = {
+    user: UserModel.ref({ index: true }),
+    sourceType: String,
+    sourceID: String,
+    reason: String
+  }
+}

--- a/packages/munar-plugin-media-blacklist/src/index.js
+++ b/packages/munar-plugin-media-blacklist/src/index.js
@@ -49,7 +49,6 @@ export default class MediaBlacklist extends Plugin {
     })
   }
 
-  @command('blacklist', { role: permissions.MODERATOR })
   async addBlacklistItem (message, itemID = '', reason = '') {
     let item
     if (itemID && /^\w+:\w+$/.test(itemID)) {
@@ -77,6 +76,15 @@ export default class MediaBlacklist extends Plugin {
     await this.createBlacklistItem(message.user, item, reason)
 
     message.reply(`Added "${item.sourceType}:${item.sourceID}" to the blacklist.`)
+  }
+
+  @command('blacklist', { role: permissions.MODERATOR })
+  triageBlacklist (message, action, ...args) {
+    if (action === 'add') {
+      return this.addBlacklistItem(message, ...args)
+    }
+
+    throw new Error('Unknown blacklist command.')
   }
 
   onAdvance = async (adapter, { next }) => {

--- a/packages/munar-plugin-media-blacklist/src/index.js
+++ b/packages/munar-plugin-media-blacklist/src/index.js
@@ -87,10 +87,37 @@ export default class MediaBlacklist extends Plugin {
     message.reply(`Added "${item.sourceType}:${item.sourceID}" to the blacklist.`)
   }
 
+  async removeBlacklistItem (message, itemID) {
+    if (!itemID || !itemID.includes(':')) {
+      throw new Error(
+        'You must provide a media item to remove from the blacklist. Use ' +
+        '`!blacklist remove sourceType:sourceID`, for example ' +
+        '`!blacklist remove youtube:QfUX9XcA7b4`.'
+      )
+    }
+
+    const [ sourceType, sourceID ] = itemID.split(':')
+    const item = { sourceType, sourceID }
+
+    const blacklisted = await this.getBlacklistItem(item)
+    if (!blacklisted) {
+      message.reply('That media is not blacklisted.')
+      return
+    }
+
+    await blacklisted.remove()
+
+    message.reply(`Removed "${item.sourceType}:${item.sourceID}" from the blacklist.`)
+  }
+
   @command('blacklist', { role: permissions.MODERATOR })
   triageBlacklist (message, action, ...args) {
     if (action === 'add') {
       return this.addBlacklistItem(message, ...args)
+    }
+
+    if (action === 'remove') {
+      return this.removeBlacklistItem(message, ...args)
     }
 
     throw new Error('Unknown blacklist command.')

--- a/packages/munar-plugin-media-blacklist/src/index.js
+++ b/packages/munar-plugin-media-blacklist/src/index.js
@@ -1,0 +1,97 @@
+import { Plugin, command, permissions } from 'munar-core'
+import Ultron from 'ultron'
+import lockskip from 'munar-helper-booth-lockskip'
+import BlacklistedMediaModel from './BlacklistedMedia'
+
+function supportsBooth (adapter) {
+  return typeof adapter.getDJBooth === 'function' &&
+    typeof adapter.getDJBooth().getMedia === 'function'
+}
+
+export default class MediaBlacklist extends Plugin {
+  static description = 'Blacklist media.'
+
+  constructor (bot, options) {
+    super(bot, options)
+
+    this.models({
+      BlacklistedMedia: BlacklistedMediaModel
+    })
+  }
+
+  get User () {
+    return this.model('User')
+  }
+  get BlacklistedMedia () {
+    return this.model('BlacklistedMedia')
+  }
+
+  enable () {
+    this.events = new Ultron(this.bot)
+    this.events.on('djBooth:advance', this.onAdvance)
+  }
+
+  disable () {
+    this.events.remove()
+  }
+
+  getBlacklistItem ({ sourceType, sourceID }) {
+    return this.BlacklistedMedia.findOne({ sourceType, sourceID })
+  }
+
+  async createBlacklistItem (user, { sourceType, sourceID }, reason) {
+    const userModel = await this.User.findOne(user.compoundId())
+    return this.BlacklistedMedia.create({
+      user: userModel.id,
+      sourceType,
+      sourceID,
+      reason
+    })
+  }
+
+  @command('blacklist', { role: permissions.MODERATOR })
+  async addBlacklistItem (message, itemID = '', reason = '') {
+    let item
+    if (itemID && /^\w+:\w+$/.test(itemID)) {
+      const [ sourceType, sourceID ] = itemID.split(':')
+      item = { sourceType, sourceID }
+    } else {
+      if (!supportsBooth(message.source)) {
+        throw new Error(
+          'This adapter does not support retrieving the current media. ' +
+          'You can still add media to the blacklist by using `!blacklist ' +
+          'sourceType:sourceID`, for example `!blacklist youtube:QfUX9XcA7b4`.'
+        )
+      }
+
+      reason = `${itemID} ${reason}`
+      item = await message.source.getDJBooth().getMedia()
+    }
+
+    const blacklisted = await this.getBlacklistItem(item)
+    if (blacklisted) {
+      message.reply('That song was already blacklisted!')
+      return
+    }
+
+    await this.createBlacklistItem(message.user, item, reason)
+
+    message.reply(`Added "${item.sourceType}:${item.sourceID}" to the blacklist.`)
+  }
+
+  onAdvance = async (adapter, { next }) => {
+    const blacklisted = await this.getBlacklistItem(next)
+    if (blacklisted) {
+      const { username } = await adapter.getDJBooth().getDJ()
+      adapter.send(
+        `@${username} This song or video is blacklisted` +
+        (blacklisted.reason ? `: ${blacklisted.reason}` : '.')
+      )
+      try {
+        await lockskip(adapter, { position: 2 })
+      } catch (e) {
+        console.error(e.stack)
+      }
+    }
+  }
+}

--- a/packages/munar-plugin-media-blacklist/src/index.js
+++ b/packages/munar-plugin-media-blacklist/src/index.js
@@ -58,13 +58,22 @@ export default class MediaBlacklist extends Plugin {
       if (!supportsBooth(message.source)) {
         throw new Error(
           'This adapter does not support retrieving the current media. ' +
-          'You can still add media to the blacklist by using `!blacklist ' +
-          'sourceType:sourceID`, for example `!blacklist youtube:QfUX9XcA7b4`.'
+          'You can still add media to the blacklist by using `!blacklist add ' +
+          'sourceType:sourceID`, for example `!blacklist add youtube:QfUX9XcA7b4`.'
         )
       }
 
       reason = `${itemID} ${reason}`
       item = await message.source.getDJBooth().getMedia()
+    }
+
+    if (!item) {
+      throw new Error(
+        'No media is currently being played. ' +
+        'You can still add specific media to the blacklist by using ' +
+        '`!blacklist add sourceType:sourceID`, for example ' +
+        '`!blacklist add youtube:QfUX9XcA7b4`.'
+      )
     }
 
     const blacklisted = await this.getBlacklistItem(item)


### PR DESCRIPTION
WIP: needs commands to remove things from the blacklist.

Adds a `!blacklist` command for moderators and up. Media that is added to the blacklist is automatically [lock-skipped](https://github.com/welovekpop/munar/tree/master/packages/munar-helper-booth-lockskip#readme) when it is played.

### `!blacklist "<reason>"`

Add the current media to the blacklist.

**Example**

 - !blacklist "This track has terrible audio quality."

### `!blacklist <media> "<reason>"`

Add a specific media to the blacklist. `<media>` contains the source type and
source ID, separated by a colon `:`.

**Example**

 - !blacklist youtube:nkMgmtU3rno "Video flickers A LOT. Please play an
   alternative version that doesn't trigger seizures."
