### PR TITLE
Add web interface plugin.

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "lerna": "2.0.0-beta.32",
+  "lerna": "2.0.0-beta.38",
   "version": "independent",
   "packages": [
     "packages/*"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "gulp-util": "^3.0.7",
     "gulp-watch": "^4.3.5",
     "jest": "^16.0.2",
-    "lerna": "2.0.0-beta.32",
+    "lerna": "2.0.0-beta.38",
     "standard": "^7.1.0",
     "through2": "^2.0.1"
   },

--- a/packages/munar-plugin-emotes/package.json
+++ b/packages/munar-plugin-emotes/package.json
@@ -14,7 +14,8 @@
   "dependencies": {
     "bluebird": "^3.3.5",
     "debug": "^2.2.0",
-    "request": "^2.72.0"
+    "request": "^2.72.0",
+    "truncate-url": "^1.0.0"
   },
   "peerDependencies": {
     "munar-core": "^1.0.0"

--- a/packages/munar-plugin-emotes/src/index.js
+++ b/packages/munar-plugin-emotes/src/index.js
@@ -5,6 +5,7 @@ import Promise from 'bluebird'
 const debug = require('debug')('munar:emotes')
 
 import { EmoteModel } from './models'
+import { renderEmotesList } from './serve'
 
 const cleanId = (id) => id.toLowerCase()
 
@@ -139,5 +140,12 @@ export default class Emotes extends Plugin {
     if (emote) {
       this.sendEmote(message, target, emote.url)
     }
+  }
+
+  async serve (req, res) {
+    res.setHeader('content-type', 'text/html')
+
+    const emotes = await this.model('Emote').find().sort('id')
+    return renderEmotesList(emotes)
   }
 }

--- a/packages/munar-plugin-emotes/src/index.js
+++ b/packages/munar-plugin-emotes/src/index.js
@@ -112,8 +112,18 @@ export default class Emotes extends Plugin {
   @command('emotes')
   async emotes (message) {
     debug('listing emotes')
+    let url
+
+    const server = this.bot.getPlugin('serve')
+    if (server) {
+      url = server.getUrl('emotes')
+    }
     if (this.options.url) {
-      message.reply(`Emotes can be found at ${this.options.url} !`)
+      url = this.options.url
+    }
+
+    if (url) {
+      message.reply(`Emotes can be found at ${url} !`)
       return
     }
     const emotes = await this.model('Emote').find().sort('id')

--- a/packages/munar-plugin-emotes/src/serve.js
+++ b/packages/munar-plugin-emotes/src/serve.js
@@ -1,0 +1,33 @@
+import truncate from 'truncate-url'
+
+export function renderEmotesList (emotes) {
+  return `
+    <!DOCTYPE html>
+    <html>
+    <head>
+      <meta charset="utf-8">
+      <link rel="stylesheet" href="https://unpkg.com/tachyons@4.6.1/css/tachyons.min.css">
+    </head>
+    <body class="bg-dark-gray near-white mh5 mv3">
+      <table class="collapse" style="margin: auto">
+        <thead><tr>
+          <th class="pv2 ph3 ttu">Name</th>
+          <th class="pv2 ph3 ttu">URL</th>
+        </tr></thead>
+        <tbody>
+          ${emotes.map((emote) => `
+            <tr class="stripe-dark">
+              <td class="pv2 ph3">${emote.id}</td>
+              <td class="pv2 ph3">
+                <a href="${emote.url}" title="${emote.url}" class="link dim light-pink" target="_blank">
+                  ${truncate(emote.url, 50)}
+                </a>
+              </td>
+            </tr>
+          `).join('')}
+        </tbody>
+      </table>
+    </body>
+    </html>
+  `.replace(/\s+/g, ' ')
+}

--- a/packages/munar-plugin-serve/README.md
+++ b/packages/munar-plugin-serve/README.md
@@ -1,3 +1,59 @@
 # munar-plugin-serve
 
-Munar plugin that adds a web interface.
+[Munar][] plugin that adds a web interface.
+
+## Installation
+
+```shell
+$ npm install --save munar-plugin-emotes
+```
+
+## Usage
+
+```json
+{
+  "plugins": [
+    ["serve", {
+      // Required: The URL that you will access your server through.
+      "baseUrl": "http://my-website.com/munar/",
+      // Defaults to 3000
+      "port": 80
+    }]
+  ]
+}
+```
+
+## For Plugin Developers
+
+Plugins can define a `serve` method, which is handled by [Micro][]:
+
+```js
+class MyPlugin extends Plugin {
+  async serve (req, res, micro) {
+    // Objects are returned as JSON
+    return { key: 'value' }
+
+    // Text is returned as-is
+    return '<h1>Hello World</h1>'
+
+    // `micro` contains helper methods from the Micro module
+    const inputParams = await micro.json(req)
+    throw micro.createError(403, 'You shall not pass!')
+    micro.send(res, 204, null)
+  }
+}
+```
+
+You can serve anything--files, a JSON API, a full web app, you name it. Your
+web service will be available at `$baseUrl/$pluginName/`. If your `baseUrl` is
+http://example.com/munar, the service for the `emotes` plugin can be found at:
+
+http://example.com/munar/emotes
+
+## License
+
+[ISC][]
+
+[Munar]: https://munar.space
+[Micro]: https://github.com/zeit/micro#readme
+[ISC]: ../../LICENSE

--- a/packages/munar-plugin-serve/README.md
+++ b/packages/munar-plugin-serve/README.md
@@ -1,0 +1,3 @@
+# munar-plugin-serve
+
+Munar plugin that adds a web interface.

--- a/packages/munar-plugin-serve/package.json
+++ b/packages/munar-plugin-serve/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "munar-plugin-serve",
+  "version": "0.0.0",
+  "description": "Munar plugin to allow other plugins to serve a web interface.",
+  "main": "lib/index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "munar-plugin"
+  ],
+  "author": "Renée Kooi <renee@kooi.me>",
+  "license": "ISC",
+  "dependencies": {
+    "micro": "^7.1.0"
+  },
+  "peerDependencies": {
+    "munar-core": "^1.0.0"
+  }
+}

--- a/packages/munar-plugin-serve/src/index.js
+++ b/packages/munar-plugin-serve/src/index.js
@@ -4,10 +4,18 @@ import micro, { createError } from 'micro'
 
 export default class Serve extends Plugin {
   static defaultOptions = {
-    port: 3000
+    port: 3000,
+    baseUrl: null
   }
 
   enable () {
+    if (!this.options.baseUrl) {
+      throw new Error(
+        'serve: Please provide the base URL that Munar will serve its pages ' +
+        'from in the `baseUrl` option.'
+      )
+    }
+
     this.server = micro(this.onRequest)
 
     this.server.listen(this.options.port)
@@ -15,6 +23,11 @@ export default class Serve extends Plugin {
 
   disable () {
     this.server.close()
+  }
+
+  getUrl (path) {
+    const base = this.options.baseUrl.replace(/\/+$/, '')
+    return `${base}/${path.replace(/^\/+/, '')}`
   }
 
   onRequest = async (req, res) => {

--- a/packages/munar-plugin-serve/src/index.js
+++ b/packages/munar-plugin-serve/src/index.js
@@ -1,0 +1,35 @@
+import { createServer } from 'http'
+import { Plugin } from 'munar-core'
+import micro, { createError } from 'micro'
+
+export default class Serve extends Plugin {
+  static defaultOptions = {
+    port: 3000
+  }
+
+  enable () {
+    this.server = micro(this.onRequest)
+
+    this.server.listen(this.options.port)
+  }
+
+  disable () {
+    this.server.close()
+  }
+
+  onRequest = async (req, res) => {
+    const pluginName = req.url.split('/')[1]
+    const plugin = await this.bot.getPlugin(pluginName)
+
+    if (!plugin || typeof plugin.serve !== 'function') {
+      throw createError(404, 'That plugin does not exist or does not expose a web interface.')
+    }
+
+    return plugin.serve(req, res, {
+      send: micro.send,
+      sendError: micro.sendError,
+      createError: micro.createError,
+      json: micro.json
+    })
+  }
+}

--- a/packages/munar-plugin-serve/src/index.js
+++ b/packages/munar-plugin-serve/src/index.js
@@ -25,6 +25,11 @@ export default class Serve extends Plugin {
       throw createError(404, 'That plugin does not exist or does not expose a web interface.')
     }
 
+    // Remove plugin name from the URL.
+    const parts = req.url.split('/')
+    parts.splice(1, 1)
+    req.url = parts.join('/')
+
     return plugin.serve(req, res, {
       send: micro.send,
       sendError: micro.sendError,

--- a/packages/munar-plugin-triggers/src/index.js
+++ b/packages/munar-plugin-triggers/src/index.js
@@ -98,7 +98,7 @@ export default class Triggers extends Plugin {
     return tokens
   }
 
-  @command('trigger', { role: permissions.MODERATOR })
+  @command('addtrigger', 'trigger', { role: permissions.MODERATOR })
   async createTrigger (message, name, ...response) {
     const Trigger = this.model('Trigger')
     const User = this.model('User')


### PR DESCRIPTION
This patch adds `munar-plugin-serve`, which allows other plugins to serve web pages (or anything else) over HTTP. It uses the [Micro](https://npmjs.com/package/micro) module as a server.

Plugins can define a `serve()` method, which will be called on requests to the `munar-plugin-serve` server. Which plugin to call is determined by the URL: /emotes calls `munar-plugin-emotes`'s `serve` method with url `/`. `/emotes/add` would call `munar-plugin-emotes`'s `serve` method with url `/add`.

For a start I've added a `serve()` method to the Emotes plugin that lists all defined emotes. In the future we could add a web interface to view and change plugin settings, for example, which could be quite useful.

![](http://i.imgur.com/Njq535d.png)