### PR TITLE
Fix history skip matching the current entry in the recent play history

### DIFF
--- a/packages/munar-adapter-plugdj/src/DJBooth.js
+++ b/packages/munar-adapter-plugdj/src/DJBooth.js
@@ -25,6 +25,20 @@ export default class DJBooth extends EventEmitter {
     return this.plug.plugged
   }
 
+  getEntry () {
+    const entry = this.plugged.getPlayback()
+    if (!entry) {
+      return null
+    }
+
+    return {
+      id: entry.historyID,
+      media: this.getMedia(),
+      user: this.getDJ(),
+      playedAt: new Date(entry.startTime)
+    }
+  }
+
   getMedia () {
     const media = this.plugged.getMedia()
     if (!media) {

--- a/packages/munar-adapter-plugdj/src/DJHistory.js
+++ b/packages/munar-adapter-plugdj/src/DJHistory.js
@@ -23,6 +23,7 @@ export default class DJHistory {
   async getRecent (limit) {
     const history = await this.getRoomHistory()
     return history.slice(0, limit).map((entry) => ({
+      id: entry.id,
       media: convertMedia(entry.media),
       user: this.convertUser(entry.user),
       playedAt: new Date(entry.timestamp)

--- a/packages/munar-adapter-uwave/src/DJBooth.js
+++ b/packages/munar-adapter-uwave/src/DJBooth.js
@@ -28,6 +28,19 @@ export default class DJBooth {
     })
   }
 
+  getEntry () {
+    if (!this.booth) {
+      return null
+    }
+
+    return {
+      id: this.booth.historyID,
+      media: this.getMedia(),
+      user: this.getDJ(),
+      playedAt: new Date(this.booth.playedAt)
+    }
+  }
+
   getMedia () {
     if (!this.booth) {
       return null

--- a/packages/munar-adapter-uwave/src/DJHistory.js
+++ b/packages/munar-adapter-uwave/src/DJHistory.js
@@ -20,6 +20,7 @@ export default class DJHistory {
     }
     const { body } = await this.uw.request('get', 'booth/history', query)
     return mergeIncludedModels(body).map((entry) => ({
+      id: entry._id,
       media: normalizeMedia(entry.media),
       user: this.uw.toBotUser(entry.user),
       playedAt: new Date(entry.playedAt)

--- a/packages/munar-plugin-dj-history-skip/src/index.js
+++ b/packages/munar-plugin-dj-history-skip/src/index.js
@@ -22,7 +22,8 @@ export default class DJHistorySkip extends Plugin {
     this.bot.removeListener('djBooth:advance', this.onAdvance)
   }
 
-  onAdvance = (adapter, { next }) => {
+  onAdvance = (adapter) => {
+    const next = adapter.getDJBooth().getEntry()
     if (supportsHistory(adapter) && next) {
       // Ensure that we only skip the next song once the previous lockskip has
       // completed.
@@ -54,9 +55,13 @@ export default class DJHistorySkip extends Plugin {
     return true
   }
 
-  async maybeSkip (adapter, media) {
+  isHistoryMatch (a, b) {
+    return this.isSameSong(a.media, b.media) && a.id !== b.id
+  }
+
+  async maybeSkip (adapter, current) {
     const history = await adapter.getDJHistory().getRecent(this.options.limit)
-    const lastPlay = history.find((entry) => this.isSameSong(entry.media, media))
+    const lastPlay = history.find((entry) => this.isHistoryMatch(entry, current))
     if (lastPlay) {
       const { username } = await adapter.getDJBooth().getDJ()
       const duration = moment.duration(Date.now() - lastPlay.playedAt, 'milliseconds')


### PR DESCRIPTION
Fixes #124 

The current play is ignored in the history by its `historyID`. This way if it takes a long time to request the play history and multiple advances happen quickly, the History Skip plugin won't find the current track somewhere in the history.