### PR TITLE
slack: Accept chat message options.

### DIFF
--- a/packages/munar-adapter-slack/package.json
+++ b/packages/munar-adapter-slack/package.json
@@ -14,7 +14,8 @@
   "author": "Renée Kooi <renee@kooi.me>",
   "license": "ISC",
   "dependencies": {
-    "@slack/client": "^3.1.0"
+    "@slack/client": "^3.1.0",
+    "rename-prop": "^1.0.0"
   },
   "peerDependencies": {
     "munar-core": "^1.0.0"

--- a/packages/munar-adapter-slack/src/Channel.js
+++ b/packages/munar-adapter-slack/src/Channel.js
@@ -1,7 +1,16 @@
 import { linkNames } from './utils'
+import rename from 'rename-prop'
 
 const defaultMessageOptions = {
   as_user: true
+}
+
+function normalizeMessageOptions (options) {
+  if (options.titleLink) {
+    rename(options, 'titleLink', 'title_link')
+  }
+
+  return options
 }
 
 export default class SlackChannel {
@@ -42,7 +51,10 @@ export default class SlackChannel {
       chatClient.postMessage(
         this.channel.id,
         linkNames(this.slack, text),
-        { ...defaultMessageOptions, ...opts }
+        normalizeMessageOptions({
+          ...defaultMessageOptions,
+          ...opts
+        })
       )
     } else {
       this.client.sendMessage(linkNames(this.slack, text), this.channel.id)

--- a/packages/munar-adapter-slack/src/Channel.js
+++ b/packages/munar-adapter-slack/src/Channel.js
@@ -1,5 +1,9 @@
 import { linkNames } from './utils'
 
+const defaultMessageOptions = {
+  as_user: true
+}
+
 export default class SlackChannel {
   constructor (slack, channel) {
     this.slack = slack
@@ -28,12 +32,21 @@ export default class SlackChannel {
     return this.slack.getChannelByName(name)
   }
 
-  reply (message, text) {
-    this.send(`@${message.username} ${text}`)
+  reply (message, text, opts = undefined) {
+    this.send(`@${message.username} ${text}`, opts)
   }
 
-  send (text) {
-    this.client.sendMessage(linkNames(this.slack, text), this.channel.id)
+  send (text, opts = undefined) {
+    if (typeof opts === 'object' && Object.keys(opts).length > 0) {
+      const chatClient = this.slack.web.chat
+      chatClient.postMessage(
+        this.channel.id,
+        linkNames(this.slack, text),
+        { ...defaultMessageOptions, ...opts }
+      )
+    } else {
+      this.client.sendMessage(linkNames(this.slack, text), this.channel.id)
+    }
   }
 
   canExecute (message) {

--- a/packages/munar-adapter-slack/src/index.js
+++ b/packages/munar-adapter-slack/src/index.js
@@ -26,6 +26,8 @@ export default class Slack extends Adapter {
 
   async connect () {
     return new Promise((resolve, reject) => {
+      this.web = new WebClient(this.options.token)
+
       this.client = new RtmClient(this.options.token, {
         dataStore: this.store,
         autoReconnect: true,


### PR DESCRIPTION
This patch checks if any message options were passed to the `send()` function, and uses the Slack Web API to send the message if so. Otherwise it uses the (much faster) RTM API like before.

This allows sending message attachments, among other things, like:

```js
adapter.send('Message', {
  attachments: [ /* ... */ ]
})
```