### PR TITLE
Initial Events Calendar

### DIFF
--- a/packages/munar-plugin-events-calendar/package.json
+++ b/packages/munar-plugin-events-calendar/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "munar-plugin-events-calendar",
+  "version": "0.0.0",
+  "description": "Munar plugin to greet new users.",
+  "main": "lib/index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "munar-plugin"
+  ],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "debug": "^2.6.3",
+    "googleapis": "^18.0.0"
+  },
+  "peerDependencies": {
+    "munar-core": "^1.0.0"
+  }
+}

--- a/packages/munar-plugin-events-calendar/package.json
+++ b/packages/munar-plugin-events-calendar/package.json
@@ -1,7 +1,7 @@
 {
   "name": "munar-plugin-events-calendar",
   "version": "0.0.0",
-  "description": "Munar plugin to greet new users.",
+  "description": "Munar plugin that uses Google Calendar to inform users about planned events.",
   "main": "lib/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -13,7 +13,9 @@
   "license": "ISC",
   "dependencies": {
     "debug": "^2.6.3",
-    "googleapis": "^18.0.0"
+    "googleapis": "^18.0.0",
+    "moment": "^2.18.1",
+    "pify": "^2.3.0"
   },
   "peerDependencies": {
     "munar-core": "^1.0.0"

--- a/packages/munar-plugin-events-calendar/src/index.js
+++ b/packages/munar-plugin-events-calendar/src/index.js
@@ -1,10 +1,48 @@
-import { Plugin, command, permissions } from 'munar-core'
+import { Plugin, command } from 'munar-core'
+import googleapis from 'googleapis'
+import pify from 'pify'
+import moment from 'moment'
 
 const debug = require('debug')('munar:events')
+const gcal = googleapis.calendar('v3')
 
 export default class EventsCalendar extends Plugin {
-  static description = 'Reaction GIF repository'
+  static description = 'Google Calendar-based event scheduling.'
 
   static defaultOptions = {
+    key: '',
+    calendar: ''
+  }
+
+  listEvents = pify(gcal.events.list)
+
+  @command('nextevent')
+  async showNextEvent (message) {
+    const body = await this.listEvents({
+      key: this.options.key,
+      calendarId: this.options.calendar,
+      timeMin: new Date().toISOString(),
+      maxResults: 1,
+      singleEvents: true,
+      orderBy: 'startTime'
+    })
+
+    if (!body.items || body.items.length === 0) {
+      message.reply('No scheduled events found.')
+      return
+    }
+
+    const event = body.items[0]
+    const start = moment(event.start.dateTime)
+    const hours = start.diff(moment(), 'hours')
+    const calendar = start.calendar(null, {
+      sameElse: `for MMMM Do`
+    })
+
+    let text = `The next event is ${event.summary}, scheduled ${calendar}.`
+    if (hours < 24) {
+      text += ` (${hours} hours from now)`
+    }
+    message.reply(text)
   }
 }

--- a/packages/munar-plugin-events-calendar/src/index.js
+++ b/packages/munar-plugin-events-calendar/src/index.js
@@ -1,0 +1,10 @@
+import { Plugin, command, permissions } from 'munar-core'
+
+const debug = require('debug')('munar:events')
+
+export default class EventsCalendar extends Plugin {
+  static description = 'Reaction GIF repository'
+
+  static defaultOptions = {
+  }
+}

--- a/packages/munar-plugin-events-calendar/src/index.js
+++ b/packages/munar-plugin-events-calendar/src/index.js
@@ -43,6 +43,16 @@ export default class EventsCalendar extends Plugin {
     if (hours < 24) {
       text += ` (${hours} hours from now)`
     }
-    message.reply(text)
+
+    message.reply(text, {
+      // For Slack!
+      attachments: [
+        {
+          title: event.summary,
+          titleLink: event.htmlLink,
+          text: event.description
+        }
+      ]
+    })
   }
 }


### PR DESCRIPTION
This adds a very basic event calendar plugin that uses a public Google Calendar. Currently, the only command it adds is `!nextevent`, which shows the next event name and time. It also shows the amount of hours until the start of the event if it is starting within the next 24 hours, which should help people who aren't in the UTC timezone (i.e. almost everyone) figure out when it starts in their local time.

On Slack it also adds an attachment (#128) that links to the google calendar event, which should make it even easier. In WE ♥ KPOP most people wouldn't use this in slack tho so ¯\_(ツ)_/¯