### PR TITLE
Add parameter validation and auto-generated usage information

### DIFF
--- a/packages/munar-core/package.json
+++ b/packages/munar-core/package.json
@@ -10,12 +10,16 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@captemulation/get-parameter-names": "^1.0.0",
     "array-includes": "^3.0.2",
     "escape-string-regexp": "^1.0.5",
+    "joi": "^10.3.0",
+    "join-component": "^1.1.0",
     "lodash.last": "^3.0.0",
     "mkdirp": "^0.5.1",
     "mongoose": "^4.4.14",
     "mongoose-model-decorators": "^0.3.1",
-    "mongoose-random": "^0.1.1"
+    "mongoose-random": "^0.1.1",
+    "pify": "^2.3.0"
   }
 }

--- a/packages/munar-core/src/Munar.js
+++ b/packages/munar-core/src/Munar.js
@@ -6,6 +6,7 @@ import { createSchema } from 'mongoose-model-decorators'
 import Promise from 'bluebird'
 
 import PluginManager from './PluginManager'
+import argumentParser from './argumentParser'
 import { UserModel, ChatMessageModel } from './models'
 
 const debug = require('debug')('munar:core')
@@ -140,6 +141,10 @@ export default class Munar extends EventEmitter {
         (com) => includes(com.names, commandName)
       )
       if (!command) return
+
+      if (command.arguments) {
+        args = await argumentParser.parse(args, command.arguments)
+      }
 
       if (command.ninjaVanish && message) {
         message.delete()

--- a/packages/munar-core/src/command.js
+++ b/packages/munar-core/src/command.js
@@ -1,10 +1,13 @@
-import * as permissions from './permissions'
 import last from 'lodash.last'
+import getParameterNames from '@captemulation/get-parameter-names'
+import * as permissions from './permissions'
+import argumentParser from './argumentParser'
 
 const commandsSym = Symbol('commands')
 
 const defaults = {
-  role: permissions.NONE
+  role: permissions.NONE,
+  arguments: []
 }
 
 const ROLE = {
@@ -25,18 +28,48 @@ export {
 command.ROLE = ROLE
 command.defaults = defaults
 command.symbol = commandsSym
+command.arg = argumentParser
 
 export default function command (...names) {
   let opts = typeof last(names) === 'object' ? names.pop() : {}
 
   return function (target, method, descriptor) {
     target[commandsSym] || (target[commandsSym] = [])
-    let com = {
+
+    const options = {
       ...defaults,
       ...opts,
       names,
       method
     }
-    target[commandsSym].push(com)
+
+    // Auto-apply labels to argument parameters, if none are given, based on
+    // the method's argument names.
+    const fn = method ? target[method] : null
+    if (fn) {
+      const paramNames = getParameterNames(fn).slice(1)
+      options.arguments = paramNames.map((paramName, i) => {
+        let argument = options.arguments[i]
+        // Add dummy argument 'validators' if there are none, so we can still
+        // attach metadata about the function parameters.
+        if (!argument) {
+          argument = command.arg.any()
+        }
+
+        // Don't know what to do with this!
+        if (!argument.isJoi) {
+          return
+        }
+
+        argument = argument.meta({ parameter: paramName })
+        if (!argument._flags.label) {
+          argument = argument.label(paramName)
+        }
+
+        return argument
+      })
+    }
+
+    target[commandsSym].push(options)
   }
 }

--- a/packages/munar-plugin-chat-log/src/index.js
+++ b/packages/munar-plugin-chat-log/src/index.js
@@ -19,12 +19,14 @@ export default class ChatLog extends Plugin {
     this.bot.removeListener('message', this.onChat)
   }
 
-  @command('lastspoke')
-  async showLastSpoke (message, ...nameParts) {
+  @command('lastspoke', {
+    description: 'Show the last time a user said something.',
+    arguments: [ command.arg.user() ]
+  })
+  async showLastSpoke (message, targetName) {
     const ChatMessage = this.bot.model('ChatMessage')
 
     const adapter = message.source.getAdapterName()
-    const targetName = nameParts.join(' ')
     try {
       const target = await this.bot.findUser(targetName, { adapter: adapter })
       if (!target) {

--- a/packages/munar-plugin-emotes/src/index.js
+++ b/packages/munar-plugin-emotes/src/index.js
@@ -11,6 +11,8 @@ const cleanId = (id) => id.toLowerCase()
 
 const IMGUR = /^https?:\/\/i\.imgur\.com\//
 
+const argEmoteName = command.arg.string().description('Emote Name')
+
 export default class Emotes extends Plugin {
   static description = 'Reaction GIF repository'
 
@@ -74,7 +76,15 @@ export default class Emotes extends Plugin {
     })
   }
 
-  @command('addemote', { role: permissions.MODERATOR, ninjaVanish: true })
+  @command('addemote', {
+    role: permissions.MODERATOR,
+    ninjaVanish: true,
+    description: 'Add a new emote.',
+    arguments: [
+      argEmoteName.required(),
+      command.arg.string().uri().description('Image URL').required()
+    ]
+  })
   async addemote (message, id, url) {
     const user = message.user
     id = cleanId(id)
@@ -100,7 +110,11 @@ export default class Emotes extends Plugin {
     message.reply(`Emote "${id}" updated!`, 10 * 1000)
   }
 
-  @command('delemote', { role: permissions.MODERATOR })
+  @command('delemote', {
+    role: permissions.MODERATOR,
+    description: 'Remove an emote.',
+    arguments: [ argEmoteName.required() ]
+  })
   async delemote (message, id) {
     debug('delemote', id)
     await this.model('Emote').remove({ _id: id })
@@ -109,7 +123,9 @@ export default class Emotes extends Plugin {
     message.reply(`Emote "${id}" removed!`, 10 * 1000)
   }
 
-  @command('emotes')
+  @command('emotes', {
+    description: 'Show a list of emotes.'
+  })
   async emotes (message) {
     debug('listing emotes')
     let url
@@ -133,15 +149,19 @@ export default class Emotes extends Plugin {
     message.reply(`Emotes: ${emoteIds.join(', ')}`)
   }
 
-  @command('emote', 'e')
+  @command('emote', 'e', {
+    description: 'Use an emote.',
+    arguments: [
+      argEmoteName.required(),
+      command.arg.user()
+        .description('User to send the emote to.')
+    ]
+  })
   async emote (message, id, username) {
     if (!id) return
 
     let target
     if (username) {
-      if (username.charAt(0) === '@') {
-        username = username.slice(1)
-      }
       target = message.source.getUserByName(username)
     }
     if (!target) {

--- a/packages/munar-plugin-karma/src/index.js
+++ b/packages/munar-plugin-karma/src/index.js
@@ -18,7 +18,13 @@ export default class UserKarma extends Plugin {
     })
   }
 
-  @command('karma')
+  @command('karma', {
+    description: 'Show a user\'s karma.',
+    arguments: [
+      command.arg.user(),
+      command.arg.string()
+    ]
+  })
   async karma (message, username, time = 'w') {
     const User = this.model('User')
     const Karma = this.model('Karma')
@@ -72,7 +78,12 @@ export default class UserKarma extends Plugin {
     }
   }
 
-  @command('karmawhores')
+  @command('karmawhores', {
+    description: 'Show the top 5 most popular users.',
+    arguments: [
+      command.arg.string()
+    ]
+  })
   async karmawhores (message, time = 'w') {
     const User = this.model('User')
     const Karma = this.model('Karma')
@@ -108,7 +119,12 @@ export default class UserKarma extends Plugin {
     }
   }
 
-  @command('bump')
+  @command('bump', {
+    description: 'Increase someone\'s karma.',
+    arguments: [
+      command.arg.user()
+    ]
+  })
   async bump (message, username, ...reason) {
     const User = this.model('User')
     const Karma = this.model('Karma')
@@ -150,7 +166,12 @@ export default class UserKarma extends Plugin {
     }
   }
 
-  @command('thump')
+  @command('thump', {
+    description: 'Decrease someone\'s karma.',
+    arguments: [
+      command.arg.user()
+    ]
+  })
   async thump (message, username, ...reason) {
     const User = this.model('User')
     const Karma = this.model('Karma')
@@ -191,7 +212,12 @@ export default class UserKarma extends Plugin {
     }
   }
 
-  @command('bitch')
+  @command('bitch', {
+    description: 'Show the user who has given you the most karma recently.',
+    arguments: [
+      command.arg.string()
+    ]
+  })
   async bitch (message, time = 'w') {
     const User = this.model('User')
     const Karma = this.model('Karma')
@@ -219,7 +245,12 @@ export default class UserKarma extends Plugin {
     }
   }
 
-  @command('pimp')
+  @command('pimp', {
+    description: 'Show the user who has received the most karma from you recently.',
+    arguments: [
+      command.arg.string()
+    ]
+  })
   async pimp (message, time = 'w') {
     const User = this.model('User')
     const Karma = this.model('Karma')
@@ -247,7 +278,9 @@ export default class UserKarma extends Plugin {
     }
   }
 
-  @command('fistbump')
+  @command('fistbump', {
+    description: 'Show a random bump.'
+  })
   async fistbump (message) {
     const User = this.model('User')
     const Karma = this.model('Karma')
@@ -266,7 +299,9 @@ export default class UserKarma extends Plugin {
     }
   }
 
-  @command('fistthump')
+  @command('fistthump', {
+    description: 'Show a random thump.'
+  })
   async fistthump (message) {
     const User = this.model('User')
     const Karma = this.model('Karma')

--- a/packages/munar-plugin-system/src/index.js
+++ b/packages/munar-plugin-system/src/index.js
@@ -1,6 +1,9 @@
 import { Plugin, command, permissions } from 'munar-core'
 import pkg from 'munar-core/package.json'
 
+const argPluginName = command.arg.string()
+  .description('Plugin Name')
+
 export default class System extends Plugin {
   static description = 'Simple tools for plugin management & system information'
 
@@ -8,12 +11,18 @@ export default class System extends Plugin {
     return this.bot.plugins
   }
 
-  @command('version')
+  @command('version', {
+    description: 'Show the current bot version.'
+  })
   version (message) {
     message.reply(`Running ${pkg.name} v${pkg.version}`)
   }
 
-  @command('reload', { role: permissions.ADMIN })
+  @command('reload', {
+    role: permissions.ADMIN,
+    description: 'Reload a plugin.',
+    arguments: [ argPluginName.required() ]
+  })
   reloadplugin (message, name) {
     try {
       this.manager().reload(name)
@@ -23,7 +32,11 @@ export default class System extends Plugin {
     }
   }
 
-  @command('unload', { role: permissions.ADMIN })
+  @command('unload', {
+    role: permissions.ADMIN,
+    description: 'Unload a plugin.',
+    arguments: [ argPluginName.required() ]
+  })
   unloadplugin (message, name) {
     try {
       this.manager().unload(name)
@@ -33,7 +46,11 @@ export default class System extends Plugin {
     }
   }
 
-  @command('load', { role: permissions.ADMIN })
+  @command('load', {
+    role: permissions.ADMIN,
+    description: 'Load a plugin.',
+    arguments: [ argPluginName.required() ]
+  })
   loadplugin (message, name) {
     try {
       this.manager().load(name)
@@ -43,7 +60,11 @@ export default class System extends Plugin {
     }
   }
 
-  @command('disable', { role: permissions.ADMIN })
+  @command('disable', {
+    role: permissions.ADMIN,
+    description: 'Disable a plugin.',
+    arguments: [ argPluginName.required() ]
+  })
   disableplugin (message, name) {
     if (name.toLowerCase() === 'system') {
       message.reply('Cannot disable the System plugin.')
@@ -58,7 +79,11 @@ export default class System extends Plugin {
     }
   }
 
-  @command('enable', { role: permissions.ADMIN })
+  @command('enable', {
+    role: permissions.ADMIN,
+    description: 'Enable a plugin.',
+    arguments: [ argPluginName.required() ]
+  })
   enableplugin (message, name) {
     const manager = this.manager()
     let plugin = manager.get(name)
@@ -74,7 +99,11 @@ export default class System extends Plugin {
     message.reply(`Plugin "${name}" enabled.`)
   }
 
-  @command('plugininfo', { role: permissions.MODERATOR })
+  @command('plugininfo', {
+    role: permissions.MODERATOR,
+    description: 'Show status information about a plugin.',
+    arguments: [ argPluginName.required() ]
+  })
   plugininfo (message, name) {
     if (!name || name.length === 0) {
       message.reply('Usage: !plugininfo "pluginname"')
@@ -94,7 +123,10 @@ export default class System extends Plugin {
     }
   }
 
-  @command('listplugins', { role: permissions.MODERATOR })
+  @command('listplugins', {
+    role: permissions.MODERATOR,
+    description: 'Show a list of known plugins, and their current status.'
+  })
   listplugins (message) {
     const manager = this.manager()
     const text = manager.known().map((name) => {
@@ -108,7 +140,10 @@ export default class System extends Plugin {
     message.reply(text.sort().join(', '))
   }
 
-  @command('exit', { role: permissions.ADMIN })
+  @command('exit', {
+    role: permissions.ADMIN,
+    description: 'Stop the bot.'
+  })
   exit (message) {
     message.reply('okay... </3 T_T')
     this.bot.stop()

--- a/packages/munar-plugin-triggers/src/index.js
+++ b/packages/munar-plugin-triggers/src/index.js
@@ -98,7 +98,15 @@ export default class Triggers extends Plugin {
     return tokens
   }
 
-  @command('addtrigger', 'trigger', { role: permissions.MODERATOR })
+  @command('addtrigger', 'trigger', {
+    role: permissions.MODERATOR,
+    description: 'Define a new trigger.',
+    arguments: [
+      command.arg.string()
+        .regex(/^.\w+$/)
+        .description('The name of the trigger.')
+    ]
+  })
   async createTrigger (message, name, ...response) {
     const Trigger = this.model('Trigger')
     const User = this.model('User')
@@ -118,7 +126,15 @@ export default class Triggers extends Plugin {
     this.add(name, response)
   }
 
-  @command('deltrigger', { role: command.ROLE.BOUNCER })
+  @command('deltrigger', {
+    role: command.ROLE.BOUNCER,
+    description: 'Delete a trigger.',
+    arguments: [
+      command.arg.string()
+        .regex(/^.\w+$/)
+        .description('The name of the trigger.')
+    ]
+  })
   async removeTrigger (message, name) {
     const Trigger = this.model('Trigger')
     name = name.toLowerCase()

--- a/packages/munar-plugin-usage/package.json
+++ b/packages/munar-plugin-usage/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "munar-plugin-usage",
+  "version": "0.0.0",
+  "description": "Munar plugin to display usage information for other plugins.",
+  "main": "lib/index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "munar-plugin"
+  ],
+  "author": "Renée Kooi <renee@kooi.me>",
+  "license": "ISC",
+  "dependencies": {
+  },
+  "peerDependencies": {
+    "munar-core": "^1.0.0"
+  }
+}

--- a/packages/munar-plugin-usage/src/index.js
+++ b/packages/munar-plugin-usage/src/index.js
@@ -1,0 +1,63 @@
+import { Plugin, command } from 'munar-core'
+
+function stringifyArgument (type, index) {
+  let message = type._flags.label
+  if (type._description) {
+    message += ` - ${type._description}`
+  }
+  if (type._flags.presence === 'required') {
+    message += ' (required)'
+  }
+
+  return message
+}
+
+export default class Usage extends Plugin {
+  getCommand (commandName) {
+    const plugins = this.bot.plugins.loaded()
+    for (const pluginName of plugins) {
+      const plugin = this.bot.plugins.get(pluginName)
+      const command = plugin &&
+        plugin.commands.find((com) => com.names.includes(commandName))
+      if (command) {
+        return command
+      }
+    }
+  }
+
+  @command('help', {
+    description: 'Show help text for Munar commands.',
+    arguments: [
+      command.arg.string().required()
+        .description('The name of the command.')
+    ]
+  })
+  showHelp (message, commandName) {
+    const command = this.getCommand(commandName)
+    if (command) {
+      const { trigger } = this.bot.options
+      const description = command.description || '(No description specified)'
+
+      let usageString = `${trigger}${commandName}`
+      command.arguments.forEach((type) => {
+        usageString += ` <${type._flags.label}>`
+      })
+
+      const title = `\`${usageString}\` - ${description}`
+      const argumentDescriptions = command.arguments
+        .map(stringifyArgument)
+        .map((descr, i) => `${i + 1}. ${descr}`)
+        .join('\n')
+
+      message.reply(title, command.arguments.length > 0 ? {
+        attachments: [
+          {
+            title: 'Arguments',
+            fallback: argumentDescriptions,
+            text: argumentDescriptions
+          }
+        ]
+      } : {})
+    }
+  }
+}

--- a/packages/munar-plugin-waitlist-raffle/src/index.js
+++ b/packages/munar-plugin-waitlist-raffle/src/index.js
@@ -38,7 +38,10 @@ export default class WaitlistRaffle extends Plugin {
     this.onEnd = this.onEnd.bind(this)
   }
 
-  @command('raffle', { role: permissions.MODERATOR })
+  @command('raffle', {
+    role: permissions.MODERATOR,
+    description: 'Start a raffle. Users can type `!play` for a chance to be moved up in the waitlist.'
+  })
   startRaffle (message) {
     if (this.running) {
       return
@@ -60,7 +63,9 @@ export default class WaitlistRaffle extends Plugin {
     )
   }
 
-  @command('play')
+  @command('play', {
+    description: 'Enter a raffle.'
+  })
   async enterRaffle (message) {
     const { user } = message
 
@@ -83,7 +88,9 @@ export default class WaitlistRaffle extends Plugin {
     }
   }
 
-  @command('withdraw')
+  @command('withdraw', {
+    description: 'Withdraw from participation in a raffle.'
+  })
   withdraw (message) {
     const { user } = message
     let i = this.players.findIndex((player) => player.id === user.id)
@@ -93,7 +100,9 @@ export default class WaitlistRaffle extends Plugin {
     message.delete()
   }
 
-  @command('players')
+  @command('players', {
+    description: 'List the users participating in the current raffle.'
+  })
   showPlayers (message) {
     if (!this.running) {
       return


### PR DESCRIPTION
Closes #121
Closes #70 

This patch uses [Joi](https://npm.im/joi) to validate parameters to commands. It also inspects the Joi validators for commands to show usage information about the command.

Joi validators can also be used to apply defaults or normalize inputs. This done in the builtin `user()` type, for example, which will strip the `@` from the start of the name if necessary.

Use `!help commandName` to get help about a command. On Adapters that support attachments, you'll get a nice block like:

![Screenie](http://i.imgur.com/E3KuqOi.png)
(`~` is used as the command trigger here)

Otherwise, hopefully the adapter puts `attachments` fallback text into the message itself. :speak_no_evil:  (I'll add this to the üWave adapter in a bit)