### PR TITLE
dj-history-skip: add `!exempt` command, closes #117

### DIFF
--- a/packages/munar-plugin-dj-history-skip/src/index.js
+++ b/packages/munar-plugin-dj-history-skip/src/index.js
@@ -1,4 +1,4 @@
-import { Plugin } from 'munar-core'
+import { Plugin, command, permissions } from 'munar-core'
 import lockskip from 'munar-helper-booth-lockskip'
 import delay from 'delay'
 import moment from 'moment'
@@ -6,12 +6,36 @@ import moment from 'moment'
 const supportsHistory = (adapter) =>
   typeof adapter.getDJHistory === 'function'
 
+const stringId = (user) => {
+  const { adapter, sourceId } = user.compoundId()
+  return `${adapter}:${sourceId}`
+}
+class Exemptions extends Set {
+  add (user) {
+    return super.add(stringId(user))
+  }
+  check (user) {
+    if (this.has(user)) {
+      this.delete(user)
+      return true
+    }
+    return false
+  }
+  has (user) {
+    return super.has(stringId(user))
+  }
+  delete (user) {
+    return super.delete(stringId(user))
+  }
+}
+
 export default class DJHistorySkip extends Plugin {
   static defaultOptions = {
     limit: 50,
     lockskipPosition: 1
   }
 
+  exemptions = new Exemptions()
   lastSkip = Promise.resolve()
 
   enable () {
@@ -20,6 +44,19 @@ export default class DJHistorySkip extends Plugin {
 
   disable () {
     this.bot.removeListener('djBooth:advance', this.onAdvance)
+  }
+
+  @command('exempt', {
+    role: permissions.MODERATOR,
+    description: 'Exempt a user from history skip for one turn.',
+    arguments: [ command.arg.user() ]
+  })
+  exempt (message, targetName) {
+    const target = message.source.getUserByName(targetName)
+    if (target) {
+      this.exemptions.add(target)
+      message.reply(`${target.username} will be exempted from history skip on their next turn.`)
+    }
   }
 
   onAdvance = (adapter) => {
@@ -61,12 +98,16 @@ export default class DJHistorySkip extends Plugin {
 
   async maybeSkip (adapter, current) {
     const history = await adapter.getDJHistory().getRecent(this.options.limit)
+    const dj = await adapter.getDJBooth().getDJ()
+    if (this.exemptions.check(dj)) {
+      return
+    }
+
     const lastPlay = history.find((entry) => this.isHistoryMatch(entry, current))
     if (lastPlay) {
-      const { username } = await adapter.getDJBooth().getDJ()
       const duration = moment.duration(Date.now() - lastPlay.playedAt, 'milliseconds')
       adapter.send(
-        `@${username} This song was played ${duration.humanize()} ago` +
+        `@${dj.username} This song was played ${duration.humanize()} ago` +
         (lastPlay.user ? ` by ${lastPlay.user.username}` : '') +
         '.'
       )


### PR DESCRIPTION
Adds an `!exempt` command that will allow a user to play a song that's in the history on their next turn.

* `!exempt <targetName>` - Exempt a user from history skip for one turn.