### PR TITLE
uwave: Set auth token in the `Authorization` header

### DIFF
--- a/packages/munar-adapter-uwave/src/index.js
+++ b/packages/munar-adapter-uwave/src/index.js
@@ -117,16 +117,18 @@ export default class UwaveAdapter extends Adapter {
     let url = `${this.apiUrl}/${endpoint}`
     const options = {
       method,
-      query: { token: this.options.token },
+      headers: {
+        authorization: `JWT ${this.options.token}`
+      },
       json: true
     }
     if (method === 'get') {
-      Object.assign(options.query, data)
+      options.query = data
     } else {
       options.body = data
-      options.headers = {
+      Object.assign(options.headers, {
         'content-type': 'application/json'
-      }
+      })
     }
     // For nested query parameters (like page[offset])
     if (options.query) {


### PR DESCRIPTION
Instead of in the query string, so it doesn't appear in server logs
anymore.